### PR TITLE
fixed lab consistency

### DIFF
--- a/Part 2/README.md
+++ b/Part 2/README.md
@@ -62,7 +62,11 @@ kubectl apply -f sdcio.yaml
 Check the pods are running
 
 ``` shell
-> kubectl get pods -n network-system 
+> kubectl get pods -n network-system
+```
+
+The output should look like:
+```shell
 NAME                             READY   STATUS    RESTARTS       AGE
 config-server-6964c6484b-8chv8   2/2     Running   2 (8m7s ago)   13h
 ```


### PR DESCRIPTION
In every other step in the lab so far, you can copy paste into your shell because the command output is separated. Doing the same here.
There is a mix in the rest of the lab. It would be good if this could be consistent, allowing for learners to copy the whole command for each step.